### PR TITLE
GDS-to-PNG rendering: Remove labels, improve compression

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,13 +97,14 @@ runs:
 
     - name: Convert SVG to PNG
       shell: bash
+      #NOTE: We avoid a cluttered labels mess by telling rsvg-convert to apply extra CSS that hides
+      # all text. Since -s expects a CSS *file*, we instead pass it "<(echo 'text{display:none;}')"
+      # which effectively creates a temporary/transient file that appears to contain the CSS we want:
       run: rsvg-convert --unlimited gds_render.svg -s <(echo 'text{display:none;}') -o gds_render_png24.png --no-keep-image-data
 
     - name: Shrink PNG
       shell: bash
-      run: |
-        pngquant --quality 10-30 --speed 1 --nofs --strip --output gds_render.png gds_render_png24.png
-        ls -al gds_render*.png
+      run: pngquant --quality 10-30 --speed 1 --nofs --strip --output gds_render.png gds_render_png24.png
 
     - name: Upload gds_render (png) artifact
       uses: actions/upload-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,13 @@ runs:
         PDK=sky130A
         EOF
 
+    # Install librsvg2-bin (for rsvg-convert) and pngquant (for heavy PNG compression)
+    - name: Install prerequisites
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: librsvg2-bin pngquant
+        version: tt04 # I think naming a version builds a reusable packages cache for that name.
+
     - name: Checkout tt-support-tools repo
       uses: actions/checkout@v3
       with:
@@ -83,9 +90,20 @@ runs:
           runs/wokwi/reports/metrics.csv
           runs/wokwi/reports/synthesis/1-synthesis*
 
-    - name: Create PNG
+    # Create and store PNG...
+    - name: Render SVG from GDS
       shell: bash
-      run: ./tt/tt_tool.py --create-png
+      run: ./tt/tt_tool.py --create-svg
+
+    - name: Convert SVG to PNG
+      shell: bash
+      run: rsvg-convert --unlimited gds_render.svg -s <(echo 'text{display:none;}') -o gds_render_png24.png --no-keep-image-data
+
+    - name: Shrink PNG
+      shell: bash
+      run: |
+        pngquant --quality 10-30 --speed 1 --nofs --strip --output gds_render.png gds_render_png24.png
+        ls -al gds_render*.png
 
     - name: Upload gds_render (png) artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Changes how the `gds` GHA renders the GDS to PNG, to greatly reduce the file size (hoping to get under 5MB for an 8x2 tile).

For info on what this does, see this older PR: https://github.com/TinyTapeout/tt03p5-submission-template/pull/4

NOTE: This uses `pngquant --quality 10-30 ...` to try and get an 8x2 tile to render to a small enough PNG file size, but it does mean some reduction in fidelity... but for most this shouldn't be noticeable. The quality option can maybe be removed conditionally in a future revision (e.g. for smaller tiles), but it might be better to work on integrating parts of this overall approach into `tt_tool.py --create-png` instead.