### PR TITLE
Allow svg rendering from pandoc

### DIFF
--- a/docs/action.yml
+++ b/docs/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y pandoc texlive-xetex
+        sudo apt-get install -y pandoc texlive-xetex librsvg2-bin
 
     - name: Create PDF
       shell: bash


### PR DESCRIPTION
Provides the rsvg-convert utility by installing the librsvg2-bin package.
This is a prerequisite for rendering svg to pdf by pandoc.