### PR TITLE
Fix #8: Render PNG from GDS using new tt_tool --create-png

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ GitHub action for hardening your Tiny Tapeout design into a manufacturable GDS f
 
 ## Usage
 
-Use the [tt04-submission-template](https://github.com/TinyTapeout/tt04-submission-template) as a starting point for your submission.
+Use the [tt05-submission-template](https://github.com/TinyTapeout/tt05-submission-template) as a starting point for your submission.
 
 ## Updating the action
 
-To update the release tag of the action, run the following command (replace `tt04` with the current tiny tapeout version):
+To update the release tag of the action, run the following command (replace `tt05` with the current tiny tapeout version):
 
 ```bash
-git tag -fa tt04 -m "Update action to tt04"
-git push origin tt04 --force
+git tag -fa tt05 -m "Update action to tt05"
+git push origin tt05 --force
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,9 @@ runs:
     - name: Checkout tt-support-tools repo
       uses: actions/checkout@v3
       with:
-        repository: algofoogle/tt-support-tools #@@@ tinytapeout/tt-support-tools
+        repository: tinytapeout/tt-support-tools
         path: tt
-        ref: gds-render-fix #@@@ tt05
+        ref: tt05
 
     - name: Setup python
       uses: actions/setup-python@v4

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
     # Create and store PNG...
     - name: Render PNG from GDS
       shell: bash
-      run: './tt/tt_tool.py --create-png-preview 2>&1 || echo "WARNING: Failed to render PNG preview from GDS; error $?"'
+      run: './tt/tt_tool.py --create-png 2>&1 || echo "WARNING: Failed to render PNG preview from GDS; error $?"'
 
     - name: Upload gds_render (png) artifact
       uses: actions/upload-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -18,19 +18,19 @@ runs:
         PDK=sky130A
         EOF
 
-    # Install librsvg2-bin (for rsvg-convert) and pngquant (for heavy PNG compression)
+    # Install packages for 'Render PNG from GDS' step:
     - name: Install prerequisites
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        packages: librsvg2-bin pngquant
+        packages: librsvg2-bin pngquant # librsvg2-bin for rsvg-convert; pngquant for heavy PNG compression.
         version: tt05 # I think naming a version builds a reusable packages cache for that name.
 
     - name: Checkout tt-support-tools repo
       uses: actions/checkout@v3
       with:
-        repository: tinytapeout/tt-support-tools
+        repository: algofoogle/tt-support-tools #@@@ tinytapeout/tt-support-tools
         path: tt
-        ref: tt05
+        ref: gds-render-fix #@@@ tt05
 
     - name: Setup python
       uses: actions/setup-python@v4
@@ -97,20 +97,9 @@ runs:
           LICENSE
 
     # Create and store PNG...
-    - name: Render SVG from GDS
+    - name: Render PNG from GDS
       shell: bash
-      run: ./tt/tt_tool.py --create-svg
-
-    - name: Convert SVG to PNG
-      shell: bash
-      #NOTE: We avoid a cluttered labels mess by telling rsvg-convert to apply extra CSS that hides
-      # all text. Since -s expects a CSS *file*, we instead pass it "<(echo 'text{display:none;}')"
-      # which effectively creates a temporary/transient file that appears to contain the CSS we want:
-      run: rsvg-convert --unlimited gds_render.svg -s <(echo 'text{display:none;}') -o gds_render_png24.png --no-keep-image-data
-
-    - name: Shrink PNG
-      shell: bash
-      run: pngquant --quality 10-30 --speed 1 --nofs --strip --output gds_render.png gds_render_png24.png
+      run: './tt/tt_tool.py --create-png-preview 2>&1 || echo "WARNING: Failed to render PNG preview from GDS; error $?"'
 
     - name: Upload gds_render (png) artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
(NOTE: Don't merge this unless https://github.com/TinyTapeout/tt-support-tools/pull/28 is merged).

To fix https://github.com/TinyTapeout/tt-gds-action/issues/8 (PNG render of large/complex GDS can fail the `gds` action) this uses a tt_tool `--create-png` update (https://github.com/TinyTapeout/tt-support-tools/pull/28) to replace old shell code with something more robust and adaptive.

NOTE: It tries to suppress anything that could be interpreted as a hard error, reporting it softly instead, so as not to stop the `gds` action on this otherwise non-essential PNG step.

Testing with a detailed 8x2 design, this took about 3.5 minutes, producing a 4.5MB PNG, while a mostly-empty 8x2 took 22 seconds to produce an 800kB PNG.