### PR TITLE
Install Python packages from requirements.txt

### DIFF
--- a/gl_test/action.yml
+++ b/gl_test/action.yml
@@ -38,9 +38,15 @@ runs:
       with:
         python-version: '3.11'
 
-    - name: Install cocotb
+    - name: Install cocotb (if required)
+      if: ${{ hashFiles('test/requirements.txt') == '' }}
       shell: bash
       run: pip install cocotb==1.8.0
+
+    - name: Install Python packages
+      if: ${{ hashFiles('test/requirements.txt') != '' }}
+      shell: bash
+      run: pip install -r test/requirements.txt
 
     - name: Install iverilog
       shell: bash


### PR DESCRIPTION
This PR changes the gl_test action so that if `test/requirements.txt` exists, the Python packages are installed from there.

If the file does not exist, cocotb is installed same as before.