### PR TITLE
feat: add info.yaml to tt_submission artifact

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,6 +147,7 @@ runs:
           src/*
           docs/*
           tt_submission/*
+          info.yaml
           LICENSE
 
     # Create and store PNG...

--- a/custom_gds/action.yml
+++ b/custom_gds/action.yml
@@ -49,6 +49,7 @@ runs:
       with:
         name: tt_submission
         path: |
+          info.yaml
           LICENSE
           docs/*
           tt_submission/*


### PR DESCRIPTION
This is a prerequisite for the precheck action verifying the analog pins against the .def template, as the particular .def file to use depends on values in `info.yaml`.