### PR TITLE
Fix the FPGA github workflow

### DIFF
--- a/fpga/ice40up5k/action.yml
+++ b/fpga/ice40up5k/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: Create the bitstream
       shell: bash
       run: |
-        python tt/tt_tool.py --create-fpga-bitstream
+        python tt/tt_fpga.py harden
 
     - name: Upload the bitstream
       if: always()


### PR DESCRIPTION
Use the `tt_fpga.py` tool instead of the `tt_tool.py`, accordigly with the documentation in https://tinytapeout.com/guides/fpga-breakout/

Should fix https://github.com/TinyTapeout/ttsky-verilog-template/issues/9