### PR TITLE
Add the action number as part of the GDS Log artefact upload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ runs:
       if: success() || failure()
       uses: actions/upload-artifact@v7
       with:
-        name: GDS_logs
+        name: "GDS_logs_${{ github.run_number }}"
         path: |
           src/*
           runs/wokwi/*


### PR DESCRIPTION
Per discussion in https://discord.com/channels/1009193568256135208/1513299711975489566, if we constantly download the GDS logs from github to investigate eg: timing violations, it's hard to differentiate between the results from the different runs. So I've added the github action number to the filename.